### PR TITLE
fix: shared prefs 0 on app start

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,14 +41,14 @@ class _MyHomePageState extends State<MyHomePage> {
   //Loading counter value on start
   Future<void> _loadCounter() async {
     for (var counter in counters) {
-      setState(() {
-        counter.loadCounter();
-      });
+      await counter.loadCounter();
+      setState(() { });
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    _loadCounter();
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),


### PR DESCRIPTION
*Description:*
- added `await` to counting loading
- add load counter inside widget build as well